### PR TITLE
Sequelize Migration Names Casing Match Model Name Casing 

### DIFF
--- a/migrations/20170925191833-create-bans-table.js
+++ b/migrations/20170925191833-create-bans-table.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('bans', {
+    return queryInterface.createTable('Bans', {
       id: {
         type: Sequelize.INTEGER,
         primaryKey: true,
@@ -30,6 +30,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('bans');
+    return queryInterface.dropTable('Bans');
   }
 };

--- a/migrations/20170925200317-create-categories-table.js
+++ b/migrations/20170925200317-create-categories-table.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('categories', {
+    return queryInterface.createTable('Categories', {
       id: {
         type: Sequelize.INTEGER,
         primaryKey: true,
@@ -27,6 +27,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('categories');
+    return queryInterface.dropTable('Categories');
   }
 };

--- a/migrations/20170925201609-create-ips-table.js
+++ b/migrations/20170925201609-create-ips-table.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('ips', {
+    return queryInterface.createTable('Ips', {
       id: {
         type: Sequelize.INTEGER,
         primaryKey: true,
@@ -18,6 +18,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('ips');
+    return queryInterface.dropTable('Ips');
   }
 };

--- a/migrations/20170925201924-create-logs-table.js
+++ b/migrations/20170925201924-create-logs-table.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('logs', {
+    return queryInterface.createTable('Logs', {
       id: {
         type: Sequelize.INTEGER,
         primaryKey: true,
@@ -30,6 +30,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('logs');
+    return queryInterface.dropTable('Logs');
   }
 };

--- a/migrations/20170925202317-create-notifications-table.js
+++ b/migrations/20170925202317-create-notifications-table.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('notifications', {
+    return queryInterface.createTable('Notifications', {
       id: {
         type: Sequelize.INTEGER,
         primaryKey: true,
@@ -27,6 +27,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('notifications');
+    return queryInterface.dropTable('Notifications');
   }
 };

--- a/migrations/20170925202519-create-pollanswers-table.js
+++ b/migrations/20170925202519-create-pollanswers-table.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('pollanswers', {
+    return queryInterface.createTable('PollAnswers', {
       id: {
         type: Sequelize.INTEGER,
         primaryKey: true,
@@ -22,6 +22,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('pollanswers');
+    return queryInterface.dropTable('PollAnswers');
   }
 };

--- a/migrations/20170925202651-create-pollquestions-table.js
+++ b/migrations/20170925202651-create-pollquestions-table.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('pollquestions', {
+    return queryInterface.createTable('PollQuestions', {
       id: {
         type: Sequelize.INTEGER,
         primaryKey: true,
@@ -22,6 +22,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('pollquestions');
+    return queryInterface.dropTable('PollQuestions');
   }
 };

--- a/migrations/20170925202801-create-pollvotes-table.js
+++ b/migrations/20170925202801-create-pollvotes-table.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('pollvotes', {
+    return queryInterface.createTable('PollVotes', {
       id: {
         type: Sequelize.INTEGER,
         primaryKey: true,
@@ -20,6 +20,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('pollvotes');
+    return queryInterface.dropTable('PollVotes');
   }
 };

--- a/migrations/20170925203055-create-postnotifications-table.js
+++ b/migrations/20170925203055-create-postnotifications-table.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('postnotifications', {
+    return queryInterface.createTable('PostNotifications', {
       id: {
         type: Sequelize.INTEGER,
         primaryKey: true,
@@ -20,6 +20,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('postnotifications');
+    return queryInterface.dropTable('PostNotifications');
   }
 };

--- a/migrations/20170925203433-create-posts-table.js
+++ b/migrations/20170925203433-create-posts-table.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('posts', {
+    return queryInterface.createTable('Posts', {
       id: {
         type: Sequelize.INTEGER,
         primaryKey: true,
@@ -31,6 +31,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('posts');
+    return queryInterface.dropTable('Posts');
   }
 };

--- a/migrations/20170925204011-create-reports-table.js
+++ b/migrations/20170925204011-create-reports-table.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('reports', {
+    return queryInterface.createTable('Reports', {
       id: {
         type: Sequelize.INTEGER,
         primaryKey: true,
@@ -24,6 +24,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('reports');
+    return queryInterface.dropTable('Reports');
   }
 };

--- a/migrations/20170925204327-create-settings-table.js
+++ b/migrations/20170925204327-create-settings-table.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('settings', {
+    return queryInterface.createTable('Settings', {
       id: {
         type: Sequelize.INTEGER,
         primaryKey: true,
@@ -19,6 +19,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('settings');
+    return queryInterface.dropTable('Settings');
   }
 };

--- a/migrations/20170925204827-create-threads-table.js
+++ b/migrations/20170925204827-create-threads-table.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('threads', {
+    return queryInterface.createTable('Threads', {
       id: {
         type: Sequelize.INTEGER,
         primaryKey: true,
@@ -34,6 +34,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('threads');
+    return queryInterface.dropTable('Threads');
   }
 };

--- a/migrations/20170925205649-create-userip-table.js
+++ b/migrations/20170925205649-create-userip-table.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('userip', {
+    return queryInterface.createTable('UserIp', {
       createdAt: Sequelize.DATE,
       updatedAt: Sequelize.DATE,
 
@@ -14,6 +14,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('userip');
+    return queryInterface.dropTable('UserIp');
   }
 };

--- a/migrations/20170925205832-create-users-table.js
+++ b/migrations/20170925205832-create-users-table.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('users', {
+    return queryInterface.createTable('Users', {
       id: {
         type: Sequelize.INTEGER,
         primaryKey: true,
@@ -31,6 +31,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('users');
+    return queryInterface.dropTable('Users');
   }
 };

--- a/migrations/20170925210453-create-admintokens-table.js
+++ b/migrations/20170925210453-create-admintokens-table.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('admintokens', {
+    return queryInterface.createTable('AdminTokens', {
       id: {
         type: Sequelize.INTEGER,
         primaryKey: true,
@@ -18,6 +18,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('admintokens');
+    return queryInterface.dropTable('AdminTokens');
   }
 };

--- a/migrations/20170927123720-add-show-description-column.js
+++ b/migrations/20170927123720-add-show-description-column.js
@@ -2,13 +2,13 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.addColumn('settings', 'showDescription', {
+    return queryInterface.addColumn('Settings', 'showDescription', {
       type: Sequelize.BOOLEAN,
       defaultValue: false
     })
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropColumn('settings', 'showDescription')
+    return queryInterface.dropColumn('Settings', 'showDescription')
   }
 };

--- a/migrations/20171203220305-add-picture-column.js
+++ b/migrations/20171203220305-add-picture-column.js
@@ -2,12 +2,12 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.addColumn('users', 'picture', {
+    return queryInterface.addColumn('Users', 'picture', {
       type: Sequelize.TEXT('long')
     })
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropColumn('users', 'picture')
+    return queryInterface.dropColumn('Users', 'picture')
   }
 };

--- a/migrations/20171208231827-create-profile-picture-table.js
+++ b/migrations/20171208231827-create-profile-picture-table.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('profilepictures', {
+    return queryInterface.createTable('ProfilePictures', {
       id: {
         type: Sequelize.INTEGER,
         primaryKey: true,
@@ -19,6 +19,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('profilepictures');
+    return queryInterface.dropTable('ProfilePictures');
   }
 };

--- a/migrations/20171208235706-add-profile-picture-column.js
+++ b/migrations/20171208235706-add-profile-picture-column.js
@@ -2,12 +2,12 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.addColumn('profilepictures', 'mimetype', {
+    return queryInterface.addColumn('ProfilePictures', 'mimetype', {
       type: Sequelize.STRING
     })
   },
 
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.dropColumn('profilepictures', 'mimetype')
+  down: (queryInterface) => {
+    return queryInterface.dropColumn('ProfilePictures', 'mimetype')
   }
 };

--- a/migrations/20180104141055-create-session-table.js
+++ b/migrations/20180104141055-create-session-table.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('sessions', {
+    return queryInterface.createTable('Sessions', {
       createdAt: Sequelize.DATE,
       updatedAt: Sequelize.DATE,
       
@@ -18,6 +18,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('sessions');
+    return queryInterface.dropTable('Sessions');
   }
 };

--- a/migrations/20181209110718-add-plaintext-column.js
+++ b/migrations/20181209110718-add-plaintext-column.js
@@ -2,12 +2,12 @@ let cheerio = require('cheerio');
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.addColumn('posts', 'plainText', {
+    await queryInterface.addColumn('Posts', 'plainText', {
       type: Sequelize.TEXT
     });
 
     let posts = await queryInterface.sequelize.query(
-      'SELECT id, content FROM posts',
+      'SELECT id, content FROM Posts',
       { type: queryInterface.sequelize.QueryTypes.SELECT }
     );
 
@@ -18,7 +18,7 @@ module.exports = {
       }
 
       return queryInterface.sequelize.query(
-        'UPDATE posts SET plainText = :text WHERE id = :id',
+        'UPDATE Posts SET plainText = :text WHERE id = :id',
         { replacements }       
       )
     });
@@ -27,6 +27,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.removeColumn('posts', 'plainText');
+    return queryInterface.removeColumn('Posts', 'plainText');
   }
 };


### PR DESCRIPTION
The names of the migration file table references must match the casing specified by the models when they get created. Hence the issue where tables cannot be found when running ``npm run start``.