### PR TITLE
Minor CSS tweak on the Start.vue route component that renders initial…

### DIFF
--- a/frontend/src/components/routes/Start.vue
+++ b/frontend/src/components/routes/Start.vue
@@ -244,7 +244,7 @@
 		position: fixed;
 		top: 0;
 		margin: 0;
-		z-index: 10;
+		z-index: 1;
 		left: 0;
 		height: 100%;
 		padding: 0;


### PR DESCRIPTION
… user account creation inputs. The admin account panel with inputs for username, password, password confirmation and create account button have a z-index greater than the header component's z-index.

I set the z-index of the panel with inputs to 1 instead of 10. This should allow the header to be visible and not hidden beneath the first panel of the start view.
